### PR TITLE
Fix includes on Centos7

### DIFF
--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -21,6 +21,7 @@
 
 #include <linux/ip.h>
 #include <linux/kthread.h>
+#include <linux/moduleparam.h>  // module_param(...)
 
 #include <drv_types.h>
 

--- a/rtl8821au/sw.c
+++ b/rtl8821au/sw.c
@@ -25,6 +25,7 @@
 
 #endif
 
+#include <linux/module.h>
 #include <linux/spinlock.h>
 
 #define RTL8821AU_DRIVER_NAME		"rtl8821au"


### PR DESCRIPTION
I tried to build the driver on Centos7 (kernel 3.10.0-514.6.2.el7.x86_64). PR fixes some missing include dependencies. Is this code still maintained? My EW7811UTC can scan, but doesn't successfully connect to my WLAN)